### PR TITLE
Dev: Fix: Update dompdf dependency to stable version ^3.1 for 0.1.0-beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "dompdf/dompdf": "dev-master",
+        "dompdf/dompdf": "^3.1",
         "iyzico/iyzipay-php": "^2.0"
     },
     "funding": [


### PR DESCRIPTION
## Issue Reference
#4 

## Description
The codenteq/cashier-iyzico 0.1.0-beta package previously required dompdf/dompdf:dev-master,
which caused installation issues in projects with minimum-stability set to stable.

Updated the dompdf dependency to ^3.1 to ensure compatibility with stable projects
while maintaining functionality.

This change resolves Composer installation errors without lowering overall project stability.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->